### PR TITLE
Migrate from master/slave vocabulary

### DIFF
--- a/projects/VM_Operations/acitoolkit-master/applications/search/aciSearchDb.py
+++ b/projects/VM_Operations/acitoolkit-master/applications/search/aciSearchDb.py
@@ -613,13 +613,13 @@ class SearchIndexLookup(object):
         items that have that term.
         :param unranked_results:
         """
-        master_items = set()
+        main_items = set()
         for results in unranked_results:
             if results[1] is not None:
-                master_items = master_items | results[1]
+                main_items = main_items | results[1]
 
         self.ranked_items = {}
-        for item in master_items:
+        for item in main_items:
             # self.ranked_items[item] = [0, 0, set()]  # score, sub-score, matching terms
             self.ranked_items[item] = {'pscore': 0, 'sscore': 0, 'terms': set()}  # score, sub-score, matching terms
 
@@ -631,7 +631,7 @@ class SearchIndexLookup(object):
         #
         # For example, if there was a 'cav' match and an 'av' match, then the score would be 4 + 2 = 6
         #
-        for atk_obj in master_items:
+        for atk_obj in main_items:
             for result in unranked_results:
                 if result[1] is not None:
                     if atk_obj in result[1]:

--- a/projects/VM_Operations/acitoolkit-master/docs/source/conf.py
+++ b/projects/VM_Operations/acitoolkit-master/docs/source/conf.py
@@ -57,8 +57,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'acitoolkit'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.